### PR TITLE
feat(side_menu): Add key parameter to SideMenu widget

### DIFF
--- a/lib/screens/widget/side_menu.dart
+++ b/lib/screens/widget/side_menu.dart
@@ -7,6 +7,7 @@ import '../../resource_manager/color_manager.dart';
 import '../../routes_manger.dart';
 
 class SideMenu extends StatelessWidget {
+  SideMenu({super.key});
   final SideMenuController sideMenuController = Get.put(SideMenuController());
 
   @override
@@ -106,7 +107,7 @@ class SideMenu extends StatelessWidget {
       },
       shape: sideMenuController.currentPage.value == pageName
           ? RoundedRectangleBorder(
-              side: BorderSide(color: ColorManager.primary, width: 2),
+              side: const BorderSide(color: ColorManager.primary, width: 2),
               borderRadius: BorderRadius.circular(5),
             )
           : null,


### PR DESCRIPTION
    
Add key parameter to the SideMenu widget to improve its performance and
maintainability. This change ensures that the widget can be uniquely
identified and efficiently updated by the framework during rebuilds.

fix(side_menu): Use constant BorderSide in RoundedRectangleBorder
    
Use a constant BorderSide instance in the RoundedRectangleBorder
construction to optimize memory usage and improve code readability.
This change ensures that the BorderSide object is not unnecessarily
recreated on each build.