### PR TITLE
🎨 Rename NextExamPage to NextExamsPage

### DIFF
--- a/lib/screens/next_exam_screen.dart
+++ b/lib/screens/next_exam_screen.dart
@@ -9,8 +9,8 @@ import '../controller/next_exam_controller.dart';
 import '../resource_manager/ReusableWidget/loading_indicators.dart';
 import 'widget/side_menu.dart';
 
-class NextExamPage extends GetView<NextExamController> {
-  const NextExamPage({super.key});
+class NextExamsPage extends GetView<NextExamController> {
+  const NextExamsPage({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
The name of the `NextExamPage` class has been changed to `NextExamsPage` to better reflect the page's purpose of displaying a list of upcoming exams.