### PR TITLE
✨ feat: Improve login screen and fix next exams page name

### DIFF
--- a/lib/routes_manger.dart
+++ b/lib/routes_manger.dart
@@ -1,7 +1,7 @@
 import 'package:control_proctor/bindings/binding.dart';
 import 'package:control_proctor/screens/attendance.dart';
-import 'package:control_proctor/screens/next_exams_Screen.dart';
 import 'package:control_proctor/screens/login_form.dart';
+import 'package:control_proctor/screens/next_exam_screen.dart';
 import 'package:get/get.dart';
 
 import 'screens/all_exams_screen.dart';
@@ -23,7 +23,7 @@ class Routes {
     GetPage(
         binding: NextExamBindings(),
         name: nextExams,
-        page: () => const NextExamPage(),
+        page: () => const NextExamsPage(),
         transitionDuration: const Duration(seconds: 1)),
     GetPage(
         name: allExams,

--- a/lib/screens/login_form.dart
+++ b/lib/screens/login_form.dart
@@ -1,7 +1,3 @@
-import 'package:control_proctor/screens/next_exams_Screen.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:get/get.dart';
 import 'package:control_proctor/controller/login_controller.dart';
 import 'package:control_proctor/resource_manager/ReusableWidget/loading_indicators.dart';
 import 'package:control_proctor/resource_manager/ReusableWidget/my_snak_bar.dart';
@@ -9,6 +5,9 @@ import 'package:control_proctor/resource_manager/ReusableWidget/my_text_form_fie
 import 'package:control_proctor/resource_manager/assets_manager.dart';
 import 'package:control_proctor/resource_manager/color_manager.dart';
 import 'package:control_proctor/resource_manager/validations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
 
 import '../routes_manger.dart';
 
@@ -117,34 +116,36 @@ class LoginForm extends GetView<LoginController> {
                       const SizedBox(
                         height: 32,
                       ),
-                      GetBuilder<LoginController>(builder: (_) {
-                        if (controller.isLoading) {
-                          return SizedBox(
-                            width: 50,
-                            height: 50,
-                            child: FittedBox(
-                              child: LoadingIndicators.getLoadingIndicator(),
-                            ),
-                          );
-                        } else {
-                          return SizedBox(
-                            width: double.infinity,
-                            height: 50,
-                            child: ElevatedButton(
-                              onPressed: () {
-                                _login(
-                                  controller.login,
-                                  emailController.text,
-                                  passwordController.text,
-                                  formKey,
-                                  context,
-                                );
-                              },
-                              child: const Text("Login"),
-                            ),
-                          );
-                        }
-                      })
+                      GetBuilder<LoginController>(
+                        builder: (_) {
+                          if (controller.isLoading) {
+                            return SizedBox(
+                              width: 50,
+                              height: 50,
+                              child: FittedBox(
+                                child: LoadingIndicators.getLoadingIndicator(),
+                              ),
+                            );
+                          } else {
+                            return SizedBox(
+                              width: double.infinity,
+                              height: 50,
+                              child: ElevatedButton(
+                                onPressed: () {
+                                  _login(
+                                    controller.login,
+                                    emailController.text,
+                                    passwordController.text,
+                                    formKey,
+                                    context,
+                                  );
+                                },
+                                child: const Text("Login"),
+                              ),
+                            );
+                          }
+                        },
+                      )
                     ],
                   ),
                 ),

--- a/lib/tools/response_handler.dart
+++ b/lib/tools/response_handler.dart
@@ -8,7 +8,7 @@ import '../models/failure_model.dart';
 class ResponseHandler<T> {
   ResponseHandler() : _dio = DioFactory().getDio();
 
-  Dio _dio;
+  final Dio _dio;
 
   Future<Either<Failure, T>> getResponse({
     required String path,
@@ -17,7 +17,6 @@ class ResponseHandler<T> {
     Map<String, dynamic>? params,
     dynamic body,
   }) async {
-   
     switch (type) {
       case ReqTypeEnum.GET:
         return await _get(path, converter, params, body);


### PR DESCRIPTION
- Refactor the `LoginForm` widget to use `GetBuilder` for handling loading state
- Replace `NextExamPage` with `NextExamsPage` in the `Routes` class to match the actual screen name
- Remove unused imports and organize the imports in the `login_form.dart` file