### PR TITLE
✨ feat(routes): Rename NextExamScreen to NextExamsScreen

### DIFF
--- a/lib/routes_manger.dart
+++ b/lib/routes_manger.dart
@@ -1,7 +1,7 @@
 import 'package:control_proctor/bindings/binding.dart';
 import 'package:control_proctor/screens/attendance.dart';
 import 'package:control_proctor/screens/login_form.dart';
-import 'package:control_proctor/screens/next_exam_screen.dart';
+import 'package:control_proctor/screens/next_exams_screen.dart';
 import 'package:get/get.dart';
 
 import 'screens/all_exams_screen.dart';


### PR DESCRIPTION
The `NextExamScreen` has been renamed to `NextExamsScreen` to better
reflect the screen's purpose, which is to display a list of upcoming
exams rather than a single exam.