### PR TITLE
✨ feat: Optimize Hive initialization in main

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,9 +7,11 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   TokenBindings().dependencies();
-  await Hive.initFlutter();
-  await Hive.openBox('Token');
-  await Hive.openBox('Profile');
+  await Future.wait([
+    Hive.initFlutter(),
+    Hive.openBox('Token'),
+    Hive.openBox('Profile'),
+  ]);
 
   runApp(MyApp());
 }


### PR DESCRIPTION
Improve the Hive initialization process by using `Future.wait()` to asynchronously
open the 'Token' and 'Profile' boxes in parallel, reducing the overall
initialization time.