### PR TITLE
✨ feat(NextExamController): Fetch next exams by proctor ID

### DIFF
--- a/lib/controllers/next_exam_controller.dart
+++ b/lib/controllers/next_exam_controller.dart
@@ -1,4 +1,5 @@
 import 'package:awesome_dialog/awesome_dialog.dart';
+import 'package:control_proctor/controllers/controllers.dart';
 import 'package:control_proctor/models/next%20exam/next_exams_res_model.dart';
 import 'package:control_proctor/tools/response_handler.dart';
 import 'package:dartz/dartz.dart';
@@ -11,23 +12,19 @@ import '../models/next exam/next_exam_res_model.dart';
 import '../resource_manager/ReusableWidget/show_dialgue.dart';
 
 class NextExamController extends GetxController {
+  final userId = Get.find<ProfileController>().cachedUserProfile!.iD;
+
   bool isLoadingGetNextExam = false;
   List<NextExamResModel> nextExamList = [];
 
-  @override
-  void onInit() {
-    super.onInit();
-    getAllExamMissionsByControlMission(16);
-  }
-
-  Future<void> getAllExamMissionsByControlMission(int controlMissionId) async {
+  Future<void> getAllExamMissionsByProctorId() async {
     isLoadingGetNextExam = true;
 
     update();
     ResponseHandler<NextExamsResModel> responseHandler = ResponseHandler();
     Either<Failure, NextExamsResModel> response =
         await responseHandler.getResponse(
-      path: "${ExamLinks.examRoomNextExam}/16",
+      path: "${ExamLinks.examRoomNextExam}/$userId",
       converter: NextExamsResModel.fromJson,
       type: ReqTypeEnum.GET,
     );
@@ -48,5 +45,11 @@ class NextExamController extends GetxController {
         update();
       },
     );
+  }
+
+  @override
+  void onInit() {
+    super.onInit();
+    getAllExamMissionsByProctorId();
   }
 }


### PR DESCRIPTION
Adds the ability to fetch the next exams by the proctor's ID instead of a hardcoded control mission ID. This change ensures that the controller can retrieve the appropriate exam data for the logged-in proctor, improving the user experience.

The key changes are:
- Introduce a `userId` variable to store the proctor's ID
- Change the `getAllExamMissionsByProctorId` method to use the `userId` variable in the API request
- Call the `getAllExamMissionsByProctorId` method in the `onInit` override to fetch the exam data on controller initialization