### PR TITLE
📝 feat(firebase): update production app name

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -6,7 +6,7 @@
     "nis-control-4cd9d": {
       "hosting": {
         "control_proctor_app_2025": [
-          "control-proctor-app-2025"
+          "staging-control-proctor-app-2025"
         ]
       }
     }


### PR DESCRIPTION
Updates the production app name in the `.firebaserc` file
from `control-proctor-app-2025` to `staging-control-proctor-app-2025`.
This change is necessary to deploy the application to the
correct hosting environment.