### PR TITLE
✨ feat: Add .firebase/* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ app.*.map.json
 
 # IDE - VSCode
 .vscode/*
+
+
+# Firebase
+.firebase/*


### PR DESCRIPTION
Adds the .firebase/* directory to the .gitignore file to
exclude it from version control. This is necessary as the
.firebase directory is used by the Firebase CLI to store
temporary files and should not be checked into the
repository.