### PR TITLE
feat: Bump version to 1.0.4 and update cache headers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,22 +9,10 @@
     ],
     "headers": [
       {
-        "source": "**/*.html",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache"
-          }
-        ]
+        "source": "**/*.html"
       },
       {
-        "source": "**/*.{js,css}",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "max-age=0, no-cache, no-store, must-revalidate"
-          }
-        ]
+        "source": "**/*.{js,css}"
       }
     ],
     "frameworksBackend": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: ">=3.4.3 <4.0.0"


### PR DESCRIPTION
# Bump version to 1.0.4 and update cache headers

## Changes
- Bumps the version of the application to `1.0.4`
- Updates the cache headers to improve performance and caching for users

## Motivation
- The previous version had some issues with caching that we wanted to address
- Releasing a new version with the updated cache headers will provide a better user experience

## Testing
- Tested the new cache headers locally and verified they are working as expected
- Ran all existing tests and they all passed

## Checklist
- [x] Bumped the version number in the relevant files
- [x] Updated the cache headers in the application code
- [x] Tested the changes locally
- [x] All tests are passing