### PR TITLE
🔖 feat(profile): Update cached user profile in Hive

### DIFF
--- a/lib/controllers/profile_controller.dart
+++ b/lib/controllers/profile_controller.dart
@@ -40,7 +40,7 @@ class ProfileController extends GetxController {
   /// This method also calls [update] to notify the widgets that depend on
   /// this controller to rebuild.
   void saveProfileToHiveBox(UserProfileModel cachedUserProfile) {
-    update();
+    _cachedUserProfile = cachedUserProfile;
     Hive.box('Profile').put('Profile', jsonEncode(cachedUserProfile.toJson()));
   }
 }


### PR DESCRIPTION
This change updates the `saveProfileToHiveBox()` method in the `ProfileController`
to first assign the `cachedUserProfile` to the `_cachedUserProfile` property before
saving it to the Hive box. This ensures that the `update()` method is called after
the profile has been updated, triggering a rebuild of the UI widgets that depend
on this controller.