### PR TITLE
✨ feat(profile_controller): Update cached profile and save to Hive

### DIFF
--- a/lib/controllers/profile_controller.dart
+++ b/lib/controllers/profile_controller.dart
@@ -41,7 +41,6 @@ class ProfileController extends GetxController {
   /// this controller to rebuild.
   void saveProfileToHiveBox(UserProfileModel cachedUserProfile) {
     _cachedUserProfile = cachedUserProfile;
-    update();
     Hive.box('Profile').put('Profile', jsonEncode(cachedUserProfile.toJson()));
   }
 }


### PR DESCRIPTION
Remove unnecessary update call after saving user profile to Hive.
This optimization avoids an unnecessary state update and improves
the overall performance of the ProfileController.