### PR TITLE
🔬 feat(version): Bump version to 1.1.9 in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 
-version: 1.1.7
+version: 1.1.9
 
 environment:
   sdk: ">=3.4.3 <4.0.0"


### PR DESCRIPTION
# Bump version to 1.1.9 in pubspec.yaml

## Changes
- Bumped the version in the `pubspec.yaml` file to `1.1.9`.

## Motivation
This change updates the version of the application to the latest release, `1.1.9`. This ensures that the application is up-to-date with the latest features and bug fixes.

## Verification
To verify the changes, please check the updated `pubspec.yaml` file to confirm that the version has been correctly updated to `1.1.9`.