### PR TITLE
✨ feat(routes): Add unknown route handling

### DIFF
--- a/lib/main_app.dart
+++ b/lib/main_app.dart
@@ -36,6 +36,7 @@ class _MyAppState extends State<MyApp> {
       getPages: Routes.routes,
       initialBinding: InitialBindings(),
       initialRoute: Routes.initialRoute,
+      unknownRoute: Routes.unknownRoute,
     );
   }
 

--- a/lib/routes_manger.dart
+++ b/lib/routes_manger.dart
@@ -13,6 +13,13 @@ class Routes {
   static const String initialRoute = "/login";
   static const String loginRoute = "/login";
   static const String nextExams = "/NextExams";
+  static final unknownRoute = GetPage(
+    name: Routes.loginRoute,
+    page: () => LoginForm(),
+    transition: Transition.fade,
+    binding: LoginBinding(),
+    transitionDuration: const Duration(seconds: 1),
+  );
   static List<GetPage> routes = [
     GetPage(
       name: loginRoute,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 
-version: 1.1.9
+version: 1.1.12
 
 environment:
   sdk: ">=3.4.3 <4.0.0"


### PR DESCRIPTION
   
Adds a new `unknownRoute` configuration to the GetX router in `main_app.dart`.
This allows the app to handle routes that are not defined in the `Routes` class,
directing the user to the login page.

The new `unknownRoute` configuration is added to the `GetMaterialApp` in the
`build` method of the `_MyAppState` class.

Additionally, the new `unknownRoute` configuration is defined in the `Routes`
class, specifying the page, transition, and binding to be used for the
unknown route.