### PR TITLE
🔒 feat: Improve student QR code scanning

### DIFF
--- a/lib/screens/students_in_exam_room/students_in_exam_room_screen.dart
+++ b/lib/screens/students_in_exam_room/students_in_exam_room_screen.dart
@@ -48,7 +48,7 @@ class StudentsInExamRoomScreen extends GetView<StudentsInExamRoomController> {
                                 String? uuid /* , studentId, name, examId */;
                                 dynamic result;
                                 result = await Get.to(
-                                  const SimpleBarcodeScannerPage(
+                                  () => const SimpleBarcodeScannerPage(
                                     scanType: ScanType.qr,
                                     appBarTitle: 'Student QR code',
                                   ),


### PR DESCRIPTION
Allows passing a function to `Get.to()` instead of a widget instance to
support late initialization of the `SimpleBarcodeScannerPage` widget.
This ensures that the controller is properly initialized before the
widget is displayed, preventing potential race conditions.