### PR TITLE
♻️ refactor(students_in_exam_room_service): handle selectedExamMissionId as a list

### DIFF
--- a/lib/services/students_in_exam_room_service.dart
+++ b/lib/services/students_in_exam_room_service.dart
@@ -32,8 +32,10 @@ class StudentsInExamRoomService extends GetxService {
   Future<void> getFromHiveBox() async {
     _selectedExamRoomId =
         await Hive.box('StudentsInExamRoom').get('selectedExamRoomId');
-    _selectedExamMissionId =
-        await Hive.box('StudentsInExamRoom').get('selectedExamMissionId');
+    _selectedExamMissionId = (await Hive.box('StudentsInExamRoom')
+            .get('selectedExamMissionId') as List<dynamic>?)
+        ?.map((e) => e as int?)
+        .toList();
   }
 
   Future<void> saveToHiveBox() async {
@@ -51,13 +53,13 @@ class StudentsInExamRoomService extends GetxService {
     await Hive.box('StudentsInExamRoom').flush();
   }
 
-  void setSelectedExamMissionId( List<int> ids) {
+  void setSelectedExamMissionId(List<int> ids) {
     _selectedExamMissionId = ids;
   }
 
   Future<void> setSelectedExamRoomAndExamMissionId({
     int? examRoomId,
-     List<int?>? examMissionIds,
+    List<int?>? examMissionIds,
   }) async {
     _selectedExamRoomId = examRoomId;
     _selectedExamMissionId = examMissionIds;


### PR DESCRIPTION
The changes made in this commit address the handling of the `selectedExamMissionId` property in the `StudentsInExamRoomService` class. Previously, the `selectedExamMissionId` was stored as a single `int` value in the Hive box. However, this approach was not suitable, as a student can be assigned to multiple exam missions.

The main changes are:

- The `getFromHiveBox()` method now retrieves the `selectedExamMissionId` as a `List<dynamic>` and converts it to a `List<int?>`.
- The `setSelectedExamMissionId()` method now accepts a `List<int>` instead of a single `int`.
- The `setSelectedExamRoomAndExamMissionId()` method now accepts a `List<int?>` for the `examMissionIds` parameter.

These changes ensure that the `StudentsInExamRoomService` can handle multiple exam missions associated with a student.