### PR TITLE
add-autofill-hints

### DIFF
--- a/lib/resource_manager/ReusableWidget/my_text_form_field.dart
+++ b/lib/resource_manager/ReusableWidget/my_text_form_field.dart
@@ -20,6 +20,7 @@ class MyTextFormFiled extends StatelessWidget {
   final Widget? suffixIcon;
   final List<TextInputFormatter>? textInputs;
   final String? title;
+  final List<String> autofillHints;
   const MyTextFormFiled({
     super.key,
     this.title,
@@ -37,6 +38,7 @@ class MyTextFormFiled extends StatelessWidget {
     this.focusBorderColor = ColorManager.primary,
     this.onFieldSubmitted,
     this.focusNode,
+    this.autofillHints = const [],
   });
 
   @override
@@ -80,6 +82,7 @@ class MyTextFormFiled extends StatelessWidget {
       onFieldSubmitted: onFieldSubmitted,
       obscureText: obscureText,
       focusNode: focusNode,
+      autofillHints: autofillHints,
     ).paddingOnly(
       top: AppPading.p25,
     );

--- a/lib/screens/login_form.dart
+++ b/lib/screens/login_form.dart
@@ -103,6 +103,7 @@ class LoginForm extends GetView<LoginController> {
                         height: 32,
                       ),
                       MyTextFormFiled(
+                        autofillHints: const [AutofillHints.username],
                         controller: emailController,
                         myValidation: Validations.requiredValidator,
                         title: "User Name",
@@ -111,6 +112,7 @@ class LoginForm extends GetView<LoginController> {
                         id: 'pass_icon',
                         builder: (_) {
                           return MyTextFormFiled(
+                            autofillHints: const [AutofillHints.password],
                             obscureText: controller.showPass,
                             controller: passwordController,
                             myValidation: Validations.requiredValidator,


### PR DESCRIPTION
# Add Autofill Hints

## Description

This pull request adds the `autofillHints` parameter to the `MyTextFormField` widget. This parameter allows users to provide a list of autofill hints, which can help improve the user experience when filling out forms on mobile devices.

Additionally, this PR adds autofill hints for the username and password fields in the login form. This feature makes it easier for users to quickly fill in their login credentials, further enhancing the overall user experience.

## Changes

1. Implemented the `autofillHints` parameter in the `MyTextFormField` widget.
2. Added autofill hints for the username and password fields in the login form.

## Benefits

- Improved user experience when filling out forms on mobile devices.
- Easier and faster login process for users.
- Consistent autofill behavior across the application.