### PR TITLE
🎨 feat(students_in_exam_room): Enhance student attendance status display

### DIFF
--- a/lib/screens/students_in_exam_room/students_in_exam_room_screen.dart
+++ b/lib/screens/students_in_exam_room/students_in_exam_room_screen.dart
@@ -328,20 +328,15 @@ class StudentsInExamRoomScreen extends GetView<StudentsInExamRoomController> {
                                               child: DecoratedBox(
                                                 decoration: BoxDecoration(
                                                   color: controller
+                                                          .selectedStudentsIds
+                                                          .contains(controller
                                                               .studentBarcodeInExamRoom!
                                                               .barcodesResModel!
                                                               .barcodes![i]
-                                                              .isCheating! ==
-                                                          1
-                                                      ? ColorManager.ornage
-                                                      : controller
-                                                                  .studentBarcodeInExamRoom!
-                                                                  .barcodesResModel!
-                                                                  .barcodes![i]
-                                                                  .attendanceStatusId ==
-                                                              13
-                                                          ? ColorManager.green
-                                                          : ColorManager.greyA8,
+                                                              .student!
+                                                              .iD!)
+                                                      ? ColorManager.green
+                                                      : ColorManager.red,
                                                 ),
                                                 child: Center(
                                                   child: FittedBox(


### PR DESCRIPTION
The changes in this commit focus on improving the display of student attendance status in the "StudentsInExamRoomScreen" widget. The key changes are:

- The background color of the student barcode widget is now determined by whether the student is selected or not, instead of their attendance status or cheating status.
- Selected students are displayed with a green background, while non-selected students are displayed with a red background.
- This change simplifies the logic and provides a more intuitive visual representation of the student's attendance status.